### PR TITLE
Tie recommendations to users - *reject after reading*

### DIFF
--- a/lib/radio_tracker/accounts/user.ex
+++ b/lib/radio_tracker/accounts/user.ex
@@ -1,12 +1,16 @@
 defmodule RadioTracker.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
+  alias RadioTracker.Schemas.Recommendation
 
   schema "users" do
     field :email, :string
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
     field :confirmed_at, :naive_datetime
+
+    has_many :given_recommendations, Recommendation, foreign_key: :recommender_id
+    has_many :received_recommendations, Recommendation, foreign_key: :recommendee_id
 
     timestamps()
   end

--- a/lib/radio_tracker/schemas/recommendation.ex
+++ b/lib/radio_tracker/schemas/recommendation.ex
@@ -2,12 +2,15 @@ defmodule RadioTracker.Schemas.Recommendation do
   use Ecto.Schema
   import Ecto.Changeset
   alias RadioTracker.Schemas.Play
+  alias RadioTracker.Accounts.User
 
   schema "recommendations" do
     field :name, :string
     field :text, :string
 
     belongs_to :play, Play
+    belongs_to :recommender, User
+    belongs_to :recommendee, User
 
     timestamps()
   end

--- a/priv/repo/migrations/20221208204831_relate_recommendation_to_user.exs
+++ b/priv/repo/migrations/20221208204831_relate_recommendation_to_user.exs
@@ -1,0 +1,10 @@
+defmodule RadioTracker.Repo.Migrations.RelateRecommendationToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:recommendations) do
+      add :recommender_id, references(:users)
+      add :recommendee_id, references(:users)
+    end
+  end
+end


### PR DESCRIPTION
**NOTE: I'm just leaving this hear as an FYI on my thought processes. Please reject the PR once you've read the description.** 

Adds the migration and ecto (ORM) relations so that recommendations can be related to the person making the recommendation and the person receiving the recommendation. 

Note that it is anticipated that a 'like' will be implemented as 'recommender' and 'recommendee' being the same user. Might have to see how this pans out... Perhaps a 'like' and a 'recommendation' should be separate entities? This seems like an important decision and now I am doubting this PR ... but am going to push on anyway. I think. 

Now I'm worried I'm going to end up with lots of `if recommender == recommendee` etc etc...

Yeah this PR is bullshit. Interesting how in the process of creating it I have been made to think about it! It's almost like peer review is a good process.  

 I think I will implement a separate `Like` entity and leave recommendations for later. Bleurgh how tedious. 