### PR TITLE
Implement `Like` in place of `Recommendation`

### DIFF
--- a/lib/radio_tracker/schemas/like.ex
+++ b/lib/radio_tracker/schemas/like.ex
@@ -1,0 +1,12 @@
+defmodule RadioTracker.Schemas.Like do
+  use Ecto.Schema
+  alias RadioTracker.Schemas.Play
+  alias RadioTracker.Accounts.User
+
+  schema "likes" do
+    belongs_to :play, Play
+    belongs_to :user, User
+
+    timestamps()
+  end
+end

--- a/lib/radio_tracker/schemas/play.ex
+++ b/lib/radio_tracker/schemas/play.ex
@@ -6,10 +6,10 @@ defmodule RadioTracker.Schemas.Play do
 
   alias RadioTracker.Repo
   alias RadioTracker.Schemas.Track
-  alias RadioTracker.Schemas.Recommendation
+  alias RadioTracker.Schemas.Like
 
   schema "plays" do
-    has_many :recommendations, Recommendation
+    has_many :likes, Like
 
     belongs_to :track, Track
 
@@ -35,7 +35,7 @@ defmodule RadioTracker.Schemas.Play do
       from p in __MODULE__,
       order_by: [desc: p.id],
       limit: 10,
-      preload: [track: [plays: :recommendations]]
+      preload: [track: [plays: :likes]]
 
     Repo.all query
   end

--- a/lib/radio_tracker/schemas/track.ex
+++ b/lib/radio_tracker/schemas/track.ex
@@ -46,12 +46,12 @@ defmodule RadioTracker.Schemas.Track do
     query =
       from t in __MODULE__,
       inner_join: p in assoc(t, :plays),
-      inner_join: r in assoc(p, :recommendations),
+      inner_join: r in assoc(p, :likes),
       on: r.play_id == p.id,
       select: t,
       order_by: [desc: count(r.id)],
       group_by: t.id,
-      preload: [plays: :recommendations]
+      preload: [plays: :likes]
     Paginator.paginate(query, params["page"])
   end
 
@@ -66,9 +66,9 @@ defmodule RadioTracker.Schemas.Track do
     Paginator.paginate(query, params["page"])
   end
 
-  def total_recs(track) do
+  def qty_likes(track) do
     track.plays
-    |> Enum.map(fn p -> length(p.recommendations) end)
+    |> Enum.map(fn p -> length(p.likes) end)
     |> Enum.sum
   end
 

--- a/lib/radio_tracker_web/components/templates/hearted_tracks/index.html.heex
+++ b/lib/radio_tracker_web/components/templates/hearted_tracks/index.html.heex
@@ -16,10 +16,10 @@
         <td><%= Dates.human_readable(track.inserted_at) %></td>
         <td>
           <span class="pink">
-            <%= if Track.total_recs(track) < 10 do %>
-            <%= String.duplicate("♥", Track.total_recs(track)) %>
+            <%= if Track.qty_likes(track) < 10 do %>
+            <%= String.duplicate("♥", Track.qty_likes(track)) %>
             <% else %>
-            <%= String.duplicate("♥", 10) %>... (<%= Track.total_recs(track) %>)
+            <%= String.duplicate("♥", 10) %>... (<%= Track.qty_likes(track) %>)
             <% end %>
           </span>
         </td>

--- a/lib/radio_tracker_web/components/templates/tracks/track.html.heex
+++ b/lib/radio_tracker_web/components/templates/tracks/track.html.heex
@@ -16,12 +16,12 @@
       <%= for play <- @track.plays do %>
       <tr>
         <td><%= Dates.human_readable(play.inserted_at) %></td>
-        <td><%= length(play.recommendations) %></td>
+        <td><%= length(play.likes) %></td>
       </tr>
       <% end %>
       <tr>
         <td></td>
-        <td><%= @total_recs %></td>
+        <td><%= @qty_likes %></td>
       </tr>
     </tbody>
   </table>

--- a/lib/radio_tracker_web/controllers/tracks_controller.ex
+++ b/lib/radio_tracker_web/controllers/tracks_controller.ex
@@ -6,9 +6,9 @@ defmodule RadioTrackerWeb.TracksController do
 
   def get(conn, params) do
     t = Repo.get(Track, params["id"])
-    |> Repo.preload(plays: :recommendations)
+    |> Repo.preload(plays: :likes)
 
-    render(conn, "track.html", track: t, total_recs: Track.total_recs(t))
+    render(conn, "track.html", track: t, qty_likes: Track.qty_likes(t))
   end
 
   def index(conn, params) do

--- a/lib/radio_tracker_web/live/six_music_now_playing.ex
+++ b/lib/radio_tracker_web/live/six_music_now_playing.ex
@@ -4,9 +4,10 @@ defmodule RadioTrackerWeb.SixMusicNowPlaying do
   use RadioTrackerWeb, :live_view
   use Timex
 
+  alias RadioTracker.Accounts
   alias RadioTracker.Repo
   alias RadioTracker.Schemas.Track
-  alias RadioTracker.Schemas.Recommendation
+  alias RadioTracker.Schemas.Like
   alias RadioTracker.Schemas.Play
   alias RadioTrackerWeb.Endpoint
 
@@ -14,16 +15,25 @@ defmodule RadioTrackerWeb.SixMusicNowPlaying do
 
   @topic "now_playing"
 
-  def mount(_params, _session, socket) do
+  def mount(_params, session, socket) do
     Endpoint.subscribe(@topic)
 
     socket = socket
     |> assign(:last_ten_plays, Play.last_ten)
     |> assign(:status, "Getting new data...")
     |> assign(:allow_undo_track_ids, [])
-    |> assign(:disabled, true)
 
-    {:ok, socket}
+    case session do
+      %{"user_token" => user_token} ->
+        user = Accounts.get_user_by_session_token(user_token)
+
+        {:ok, socket
+        |> assign(:current_user, user)
+        |> assign(:disabled, false)}
+      _ ->
+        {:ok, socket
+        |> assign(:disabled, true)}
+    end
   end
 
   def handle_info(%{event: "new_track", payload: %{allow_undo_track_ids: allow_undo_track_ids}} = data, socket) do
@@ -57,7 +67,12 @@ defmodule RadioTrackerWeb.SixMusicNowPlaying do
     play = Repo.get(Play, data["play-id"])
     |> Repo.preload([:track])
 
-    Repo.insert(%Recommendation{name: "me", text: "stuff", play: play})
+    Repo.insert(
+      %Like{
+        play: play,
+        user: socket.assigns.current_user
+      }
+    )
 
     Endpoint.broadcast(
       @topic,
@@ -73,10 +88,10 @@ defmodule RadioTrackerWeb.SixMusicNowPlaying do
 
   def handle_event("undo", data, socket) do
     play = Repo.get(Play, data["play-id"])
-    |> Repo.preload([:recommendations, :track])
+    |> Repo.preload([:likes, :track])
 
-    unless length(play.recommendations) === 0 do
-        Repo.delete(List.last(play.recommendations))
+    unless length(play.likes) === 0 do
+        Repo.delete(List.last(play.likes))
 
         Endpoint.broadcast(
           @topic,

--- a/lib/radio_tracker_web/live/six_music_now_playing.html.heex
+++ b/lib/radio_tracker_web/live/six_music_now_playing.html.heex
@@ -27,9 +27,9 @@
             disabled={@disabled}
           >
             <span class="pink is-size-3">♥</span>
-            <%= if (Track.total_recs(play.track) > 0) do %>
+            <%= if (Track.qty_likes(play.track) > 0) do %>
               <span class="recommendation-count">
-                <%= Track.total_recs(play.track) %>
+                <%= Track.qty_likes(play.track) %>
               </span>
             <% end %>
           </button>

--- a/priv/repo/migrations/20221209210410_create_likes_table.exs
+++ b/priv/repo/migrations/20221209210410_create_likes_table.exs
@@ -1,0 +1,12 @@
+defmodule RadioTracker.Repo.Migrations.CreateLikesTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:likes) do
+      add :play_id, references (:plays)
+      add :user_id, references (:users)
+
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
Follows on from previous (rejected) PR. 

Adds the migration and schema for `Like` entities which are effectively pivot objects between users and plays.

Also changes all the places where recommendations are used. There's no data migration for recommendations -> likes as there is no data anywhere which needs retaining yet.

`Recommendation` is left in the code base for later use in the context of 'social features' 

Apologies for the mega-commit. 
